### PR TITLE
Fix on the "Scope inside buildings" bug (inventory.ts)

### DIFF
--- a/server/src/inventory/inventory.ts
+++ b/server/src/inventory/inventory.ts
@@ -485,7 +485,14 @@ export class Inventory {
                 for (let i = Scopes.definitions.length - 1; i >= 0; i--) {
                     const scope = Scopes.definitions[i];
                     if (this.items.hasItem(scope.idString)) {
-                        this.scope = this.owner.effectiveScope = scope;
+
+                        // --------------------------------------------------------------------------------------------
+                        // BUG FIX: The scope "hack" in buildings. We do not need to set "effectiveScope" if the
+                        // player is inside a bulding, because it's already set to the 1x by the building in player.ts
+                        // --------------------------------------------------------------------------------------------
+                        this.scope = this.owner.isInsideBuilding ? scope : this.owner.effectiveScope = scope;
+                        // --------------------------------------------------------------------------------------------
+
                         break;
                     }
                 }


### PR DESCRIPTION
Small bug fix so that when you drop a scope inside a building you no longer have it's zoom level but the 1x zoom level as it should be.

The issue was quite simple. In `player.ts`, the `effectiveScope` is set to 1x (`DEFAULT_SCOPE`) when the player is inside a building, however, in `inventory.ts`, the effectiveScope is set again but there is no check about being inside building. So yeah.